### PR TITLE
Refactor GAuthAuthenticationAutoConfiguration 분리

### DIFF
--- a/src/main/java/dev/yangsijun/gauth/autoconfiguration/GAuthAuthenticationAutoConfiguration.java
+++ b/src/main/java/dev/yangsijun/gauth/autoconfiguration/GAuthAuthenticationAutoConfiguration.java
@@ -1,6 +1,5 @@
 package dev.yangsijun.gauth.autoconfiguration;
 
-import dev.yangsijun.gauth.authentication.GAuthAuthenticationProvider;
 import dev.yangsijun.gauth.configurer.GAuthLoginConfigurer;
 import dev.yangsijun.gauth.core.user.GAuthUser;
 import dev.yangsijun.gauth.registration.GAuthRegistration;
@@ -15,25 +14,25 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 @AutoConfiguration
 @ConditionalOnClass(GAuthTemplate.class)
 @AutoConfigureAfter(AuthenticationConfiguration.class)
+@Import({AuthenticationConfiguration.class, GAuthClientAutoConfiguration.class})
 public class GAuthAuthenticationAutoConfiguration {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final GAuth gAuth;
     private final GAuthTemplate gAuthTemplate;
-    private final GAuthUserService gAuthUserService;
     private final GAuthRegistration gAuthRegistration;
 
-    public GAuthAuthenticationAutoConfiguration(AuthenticationConfiguration authenticationConfiguration, GAuth gAuth, GAuthTemplate gAuthTemplate, GAuthUserService gAuthUserService, GAuthRegistration gAuthRegistration) {
+    public GAuthAuthenticationAutoConfiguration(AuthenticationConfiguration authenticationConfiguration, GAuth gAuth, GAuthTemplate gAuthTemplate, GAuthRegistration gAuthRegistration) {
         this.authenticationConfiguration = authenticationConfiguration;
         this.gAuth = gAuth;
         this.gAuthTemplate = gAuthTemplate;
-        this.gAuthUserService = gAuthUserService;
         this.gAuthRegistration = gAuthRegistration;
     }
 
@@ -47,12 +46,6 @@ public class GAuthAuthenticationAutoConfiguration {
     @ConditionalOnMissingBean(GAuthLoginConfigurer.class)
     public GAuthLoginConfigurer<HttpSecurity> autoGAuthAuthenticationConfigurer() {
         return new GAuthLoginConfigurer<>(gAuthRegistration, authenticationConfiguration);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(GAuthAuthenticationProvider.class)
-    public GAuthAuthenticationProvider autoGAuthAuthenticationProvider() {
-        return new GAuthAuthenticationProvider(gAuthUserService);
     }
 
     @Bean

--- a/src/main/java/dev/yangsijun/gauth/autoconfiguration/GAuthAuthenticationProviderAutoConfiguration.java
+++ b/src/main/java/dev/yangsijun/gauth/autoconfiguration/GAuthAuthenticationProviderAutoConfiguration.java
@@ -1,0 +1,33 @@
+package dev.yangsijun.gauth.autoconfiguration;
+
+import dev.yangsijun.gauth.authentication.GAuthAuthenticationProvider;
+import dev.yangsijun.gauth.core.user.GAuthUser;
+import dev.yangsijun.gauth.template.GAuthTemplate;
+import dev.yangsijun.gauth.userinfo.GAuthAuthorizationRequest;
+import dev.yangsijun.gauth.userinfo.GAuthUserService;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@ConditionalOnClass(GAuthTemplate.class)
+@AutoConfigureAfter(GAuthAuthenticationAutoConfiguration.class)
+@Import({GAuthAuthenticationAutoConfiguration.class})
+public class GAuthAuthenticationProviderAutoConfiguration {
+
+    private final GAuthUserService<GAuthAuthorizationRequest, GAuthUser> gAuthUserService;
+
+    public GAuthAuthenticationProviderAutoConfiguration(GAuthUserService<GAuthAuthorizationRequest, GAuthUser> gAuthUserService) {
+        this.gAuthUserService = gAuthUserService;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(GAuthAuthenticationProvider.class)
+    public GAuthAuthenticationProvider autoGAuthAuthenticationProvider() {
+        return new GAuthAuthenticationProvider(gAuthUserService);
+    }
+
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
     dev.yangsijun.gauth.autoconfiguration.GAuthClientAutoConfiguration,\
-    dev.yangsijun.gauth.autoconfiguration.GAuthAuthenticationAutoConfiguration
+    dev.yangsijun.gauth.autoconfiguration.GAuthAuthenticationAutoConfiguration,\
+    dev.yangsijun.gauth.autoconfiguration.GAuthAuthenticationProviderAutoConfiguration


### PR DESCRIPTION
## 요약
`GAuthAuthenticationAutoConfiguration` 의 `AuthenticationProvider` 빈 생성 메서드만 따로 `GAuthAuthenticationProviderAutoConfiguration`로 분리 
## 이유
테스트 시 의존성 사이클이 발생하기 때문