### PR TITLE
2.0.1 hotfix build

### DIFF
--- a/src/main/java/dev/yangsijun/gauth/userinfo/DefaultGAuthUserService.java
+++ b/src/main/java/dev/yangsijun/gauth/userinfo/DefaultGAuthUserService.java
@@ -57,7 +57,7 @@ public class DefaultGAuthUserService
                         GET_USERINFO_URL,
                         HttpMethod.GET,
                         new HttpEntity<>(headers),
-                        new ParameterizedTypeReference<>() {
+                        new ParameterizedTypeReference<Map<String, Object>>() {
                         }
                 ));
 
@@ -93,7 +93,7 @@ public class DefaultGAuthUserService
                         GET_TOKEN_URL,
                         HttpMethod.POST,
                         new HttpEntity<>(body, headers),
-                        new ParameterizedTypeReference<>() {
+                        new ParameterizedTypeReference<Map<String, String>>() {
                         }
                 ));
         return response.getBody();


### PR DESCRIPTION
jitpack 배포 시 사용되는 jdk11 버전에서 발생하는 JDK-8212586 문제로 인해서 complie 시 에러가 발생하던 문제를 수정하였습니다.

# 참고

[익명클래스 생성에서 타입추론 컴파일 에러](https://reiphiel.tistory.com/130)
[[JDK-8212586] NullPointerException when compile generic ParameterizedTypeReference - Java Bug System](https://bugs.openjdk.org/browse/JDK-8212586)